### PR TITLE
Fixed #1 & other changes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,3 +7,7 @@ version = "0.1.0"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
+ReplMaker = "b873ce64-0db9-51f5-a568-4457d8e49576"
+
+[compat]
+ReplMaker = "0.2.7"

--- a/src/AskAI.jl
+++ b/src/AskAI.jl
@@ -1,5 +1,6 @@
 module AskAI
 using HTTP, JSON3, Markdown
+using ReplMaker: initrepl
 
 include("brain.jl")
 
@@ -31,6 +32,14 @@ $(@__MODULE__).setapi("1234567890abcdef1234567890abcdef")
         setapi("")
         display(Markdown.parse(msg))
     end
+
+    isinteractive() || return
+    initrepl(s -> Main.eval(Meta.parse("AskAI.@ai \"$s\""));
+             prompt_text="ask ai> ",
+             prompt_color=104,
+             start_key='}',
+             mode_name=:askai,
+            )
 
 end
 
@@ -128,7 +137,6 @@ to add the module to the Main scope, which will be used by @AI to call julia cod
         # res
     end
 end
-
 
 export @ai, @AI, exe, reset
 

--- a/src/AskAI.jl
+++ b/src/AskAI.jl
@@ -3,16 +3,20 @@ using HTTP, JSON3, Markdown
 
 include("brain.jl")
 
+AI_API_KEY = "API key not set"
+prompt_to_get_code = "if the answer contains code, only output the raw code in julia"
 
-######################################
-# check for the required AI_API_KEY  #
-######################################
-if haskey(ENV, "AI_API_KEY")
-    println("AI_API_KEY is set to $(ENV["AI_API_KEY"])")
-    AI_API_KEY = ENV["AI_API_KEY"]
-else
-    msg = """
-API_KEY is needed. please set it as in environment variable:
+function __init__()
+    global AI_API_KEY
+    ######################################
+    # check for the required AI_API_KEY  #
+    ######################################
+    if haskey(ENV, "AI_API_KEY")
+        println("AI_API_KEY is set to $(ENV["AI_API_KEY"])")
+        setapi(ENV["AI_API_KEY"])
+    else
+        msg = """
+API_KEY is needed. please set it as an environment variable:
 
 ```julia
 ENV["AI_API_KEY"]="1234567890abcdef1234567890abcdef"
@@ -20,12 +24,14 @@ ENV["AI_API_KEY"]="1234567890abcdef1234567890abcdef"
 
 or set it through function `setapi()`
 ```julia
-setapi("1234567890abcdef1234567890abcdef")
+$(@__MODULE__).setapi("1234567890abcdef1234567890abcdef")
 
 ```
 """
-    AI_API_KEY = ""
-    display(Markdown.parse(msg))
+        setapi("")
+        display(Markdown.parse(msg))
+    end
+
 end
 
 """
@@ -34,11 +40,10 @@ set the API_KEY
 setapi("1234567890abcdef1234567890abcdef")
 ```
 """
-setapi(api::AbstractString) = global AI_API_KEY = api
-
-
-prompt_to_get_code = "if the answer contains code, only output the raw code in julia"
-Brain = AIBrain(api=AI_API_KEY, prompt = prompt_to_get_code )
+function setapi(api::AbstractString)
+    global AI_API_KEY = api
+    global Brain = AIBrain(api=AI_API_KEY, prompt = prompt_to_get_code )
+end
 
 
 """


### PR DESCRIPTION
 - Moved some of the initialization code into `__init__()`
   (This ensures that the initialization code is run only when the module is loaded and not when it is pre-compiled)
 - Added Brain reinitialization to `setapi()` (I think that this is what fixes #1 )
 - Improved the message that asks for the API key to be set
   (It had a bug and a typo)